### PR TITLE
Fixed setAction_Up(true) making listener work incorrectly if Brighntess slider attached

### DIFF
--- a/colorpickerview/src/main/java/com/skydoves/colorpickerview/ColorPickerView.java
+++ b/colorpickerview/src/main/java/com/skydoves/colorpickerview/ColorPickerView.java
@@ -185,8 +185,10 @@ public class ColorPickerView extends FrameLayout {
             handleFlagView(getCenterPoint(snapPoint.x, snapPoint.y));
             notifyToSlideBars();
 
-            if(ACTON_UP && event.getAction() == MotionEvent.ACTION_UP) {
-                fireColorListener(getColor(), true);
+            if(ACTON_UP) {
+                if (event.getAction() == MotionEvent.ACTION_UP) {
+                    fireColorListener(getColor(), true);
+                }
             } else {
                 fireColorListener(getColor(), true);
             }

--- a/colorpickerview/src/main/java/com/skydoves/colorpickerview/sliders/AbstractSlider.java
+++ b/colorpickerview/src/main/java/com/skydoves/colorpickerview/sliders/AbstractSlider.java
@@ -121,20 +121,14 @@ public abstract class AbstractSlider extends FrameLayout {
         if(colorPickerView != null) {
             switch (event.getActionMasked()) {
                 case MotionEvent.ACTION_UP:
-                    if (colorPickerView.getACTON_UP()) {
-                        selector.setPressed(true);
-                        onTouchReceived(event);
-                        return true;
-                    }
-                    break;
+                    selector.setPressed(true);
+                    onTouchReceived(event);
+                    return true;
                 case MotionEvent.ACTION_DOWN:
                 case MotionEvent.ACTION_MOVE:
-                    if (!colorPickerView.getACTON_UP()) {
-                        selector.setPressed(true);
-                        onTouchReceived(event);
-                        return true;
-                    }
-                    break;
+                    selector.setPressed(true);
+                    onTouchReceived(event);
+                    return true;
                 default:
                     selector.setPressed(false);
                     return false;
@@ -154,7 +148,13 @@ public abstract class AbstractSlider extends FrameLayout {
 
         Point snapPoint = new Point((int)event.getX(), (int)event.getY());
         selector.setX(snapPoint.x - (selector.getMeasuredWidth() / 2));
-        colorPickerView.fireColorListener(assembleColor(), true);
+        if (colorPickerView.getACTON_UP()) {
+            if (event.getAction() == MotionEvent.ACTION_UP) {
+                colorPickerView.fireColorListener(assembleColor(), true);
+            }
+        } else {
+            colorPickerView.fireColorListener(assembleColor(), true);
+        }
 
         int maxPos = getMeasuredWidth() - selector.getMeasuredWidth();
         if(selector.getX() >= maxPos) selector.setX(maxPos);


### PR DESCRIPTION
Fixed an issue where if brightness slider is attached to color picker and `setACTION_UP()` is set to true, the listener keeps triggering even while dragging.

Also fixed Brightness slider not moving while dragging if `setACTION_UP()` is set to true.